### PR TITLE
Fix: Improve graceful shutdown logic in server.ts

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -50,13 +50,34 @@ async function createCustomServer() {
 
     const gracefulShutdown = (signal: string) => {
       console.log(`[${signal}] Received, shutting down...`);
-      io.close(() => {
-        console.log('[Socket.IO] Server closed.');
-        server.close(() => {
+
+      const closeHttpServer = new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) {
+            console.error('[HTTP] Server close error:', err);
+            return reject(err);
+          }
           console.log('[HTTP] Server closed.');
-          process.exit(0);
+          resolve();
         });
       });
+
+      const closeSocketIoServer = new Promise<void>((resolve) => {
+        io.close(() => {
+          console.log('[Socket.IO] Server closed.');
+          resolve();
+        });
+      });
+
+      Promise.all([closeHttpServer, closeSocketIoServer])
+        .then(() => {
+          console.log('All servers closed. Exiting.');
+          process.exit(0);
+        })
+        .catch((err) => {
+          console.error('Error during graceful shutdown:', err);
+          process.exit(1);
+        });
     };
 
     // Gracefully handle shutdown signals


### PR DESCRIPTION
The previous implementation of the graceful shutdown mechanism nested the HTTP server's `close()` call within the callback of the Socket.IO server's `close()` call. This created a potential hang condition where the entire process would fail to terminate if the Socket.IO server did not close correctly.

This commit refactors the `gracefulShutdown` function to handle the closing of the HTTP and Socket.IO servers concurrently using `Promise.all`. This decouples the shutdown processes, making them more robust and ensuring that the server can terminate more reliably.

Attempts to create an automated test to verify this behavior were unsuccessful due to persistent instabilities in the testing environment when spawning the server as a child process. The fix addresses a clear logical flaw in the shutdown sequence.